### PR TITLE
fix tde-i18n installation check

### DIFF
--- a/BUILD-TDE.sh
+++ b/BUILD-TDE.sh
@@ -460,10 +460,8 @@ do
 # Re: http://serverfault.com/questions/71285/in-centos-4-4-how-can-i-strip-escape-sequences-from-a-text-file
   sed -ri "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" $TMP/${package}-build-log || ${EXIT_FAIL:-"true"}
 
-# tde-i18n package installation is handled in tde-i18n.SlackBuild because if more than one i18n package is being built, only the last one will be installed by upgradepkg
-# Note to self: this alteration appears to fix the problem (Erroing and refusing to compile) BUT makes the script recomnpile it if you run the
-# script with re-use even though it is installed. Yeah and it gets really annoying when testing new things lol
-if [[ $INST == 1 ]] && [[ ${package} != tde-i18n ]]; then upgradepkg --install-new --reinstall $TMP/${package}-$(eval echo $version)-*-${build}*.txz
+checkinstall ()
+{
 if [[ $(ls /var/log/packages/${package}-*$(eval echo $version)-*-${build}*) ]]; then
 sed -i "s|$dir ||" $TMPVARS/TDEbuilds
 else
@@ -472,7 +470,15 @@ echo "
       Check the build log $TMP/${package}-build-log
       "
 ${EXIT_FAIL:-":"}
-fi;fi
+fi
+}
+# tde-i18n package installation is handled in tde-i18n.SlackBuild because if more than one i18n package is being built, only the last one will be installed by upgradepkg
+if [[ $INST == 1 ]] && [[ ${package} != tde-i18n ]]; then upgradepkg --install-new --reinstall $TMP/${package}-$(eval echo $version)-*-${build}*.txz
+checkinstall
+## test for last language in the I18N list to ensure they've all been built
+elif [[ $INST == 1 ]] && [[ ${package} == tde-i18n ]]; then package=${package}-$(cat $TMPVARS/LASTLANG)
+checkinstall
+fi
 
   # back to original directory
   cd $ROOT

--- a/Core/tde-i18n/tde-i18n.SlackBuild
+++ b/Core/tde-i18n/tde-i18n.SlackBuild
@@ -57,7 +57,6 @@ cd ${PRGNAM}-$lang/build
   cmake \
     -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
     -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
-    -DCMAKE_CXX_FLAGS_RELEASE:STRING="$SLKCFLAGS" \
     -DCMAKE_C_COMPILER=${COMPILER} \
     -DCMAKE_CXX_COMPILER=${COMPILER_CXX} \
     -DCMAKE_BUILD_TYPE=Release \
@@ -152,3 +151,5 @@ upgradepkg --install-new --reinstall $OUTPUT/${PRGNAM}-${lang}-${VERSION}-${ARCH
 fi
 
 done
+
+echo $lang > $TMPVARS/LASTLANG


### PR DESCRIPTION
@Thorn-Inurcide 
I've noticed your comments about the tde-i18n build. This was because the build was out of the BUILD-TDE.sh loop at the time and so the entry in TDEbuilds wasn't being deleted on a successful build/installation. I think this fixes it, I checked a number of combinations and it worked ok.


And this message comes up during the cmake:
```
  Manually-specified variables were not used by the project:

    CMAKE_CXX_FLAGS_RELEASE
```
So `-DCMAKE_CXX_FLAGS_RELEASE:STRING="$SLKCFLAGS" \` can be removed.