### PR TITLE
Modified koffice.SlackBuild as detailed in issue 37 to fix chalk crash.

### DIFF
--- a/Apps/koffice/koffice.SlackBuild
+++ b/Apps/koffice/koffice.SlackBuild
@@ -25,13 +25,56 @@
 
 PRGNAM=koffice
 VERSION=${VERSION:-$TDEVERSION}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_tde}
+
+## if GraphicsMagick not chosen in BUILD-TDE.sh, set up build to use ImageMagick
+[[ ${USE_GM_LIBS:-} != yes ]] && IM_LDFLAGS=$($(which Magick++-config) --libs)
+
+## build with libpng-1.4 - set in BUILD-TDE.sh - loading pngs in chalk/krita crashes with libpng16
+[[ ${USE_PNG14:-} == yes ]] && \
+[[ $(ls -l /usr/include/png.h) != *libpng14* ]] && \
+{ [[ $(getconf LONG_BIT) == 64 ]] && ARCH=x86_64 || ARCH=i686
+} && \
+{ installpkg $LIBPNG_TMP/libpng-1.4.20-$ARCH-1.txz || \
+{ echo -e "\033[39;1m\n (re)install libpng-1.4 \n\033[0m" && \
+exit
+}
+} || true
+
 
 source ../../get-source.sh
 getsource_fn
 
 untar_fn
+
+## fix chalk crashing - set liblcms as a direct dependency - see issue 37 for details
+sed -i '2iLCMS1LIBS = -llcms' chalk/Makefile.am
+sed -i 's|LDADD) \\$(LIBS)|& \\$(LCMS1LIBS)|' admin/am_edit
+
+## fix chalk crashing when launched from Applications menu
+sed -i "s|Exec=.*$|Exec=$INSTALL_TDE/bin/chalk %U|" chalk/chalk.desktop
+
+## revert name 'chalk' to 'krita' - set in BUILD-TDE.sh
+[[ ${REVERT:-} == yes ]] && APP=krita && \
+(echo -e "\n Reverting chalk to krita .. \n"
+## Rename directories and files:
+mv chalk krita
+for file in $(find . -name "*chalk*")
+do
+rename chalk krita $file 2>/dev/null || true # errors will be corrected next loop
+done
+## repeat for instances of 'chalk' appearing twice:
+for file in $(find . -name "*chalk*")
+do
+rename chalk krita $file
+done
+mv "krita/doc/Developing Chalk Plugins.odt" "krita/doc/Developing Krita Plugins.odt"
+## Rename contents:
+find . -type f -exec sed -i -e 's/chalk/krita/g' {} \;
+find . -type f -exec sed -i -e 's/CHALK/KRITA/g' {} \;
+find . -type f -exec sed -i -e 's/Chalk/Krita/g' {} \;
+sed -i 's|Swedish for krita|Swedish for chalk|' krita/README)
 
 listdocs_fn
 
@@ -42,7 +85,7 @@ chown_fn
 cd_builddir_fn
 
 # Refusing to compile with Clang =[
-LDFLAGS="${SLKLDFLAGS} $($(which Magick++-config) --libs)" \
+LDFLAGS="${SLKLDFLAGS} ${IM_LDFLAGS:-}" \
 CFLAGS="${SLKCFLAGS} $TQT_INCLUDE_PATH" \
 CXXFLAGS="${SLKCFLAGS}" \
 CC="gcc" \
@@ -52,8 +95,7 @@ CXX="g++" \
    --sysconfdir="/etc/trinity" \
    --mandir=${INSTALL_TDE}/man \
    --disable-rpath \
-   --enable-closure \
-   --build=$ARCH-slackware-linux
+   --enable-closure
 
 make_fn
 
@@ -71,7 +113,7 @@ echo "
 # make exactly 11 lines for the formatting to be correct.  It's also
 # customary to leave one space after the ':'.
 
-        |-----handy-ruler------------------------------------------------------|
+$PRGNAM|-----handy-ruler------------------------------------------------------|
 $PRGNAM: $PRGNAM (Office Suite)
 $PRGNAM:
 $PRGNAM: KOffice is a collection of office applications linked together by a 
@@ -97,8 +139,9 @@ if [ -d usr/share/icons/hicolor ]; then
     chroot . /usr/bin/gtk-update-icon-cache -f -t ${INSTALL_TDE}/share/icons/hicolor 1> /dev/null 2> /dev/null
   fi
 fi
-
 EOINS
 
-
 makepkg_fn
+
+## restore libpng16 links
+[[ ${USE_PNG14:-} == yes ]] && libpng16_fn || true

--- a/Misc/GraphicsMagick/GraphicsMagick.SlackBuild
+++ b/Misc/GraphicsMagick/GraphicsMagick.SlackBuild
@@ -24,11 +24,12 @@
 #   SUCH DAMAGE.
 
 PRGNAM=GraphicsMagick
-VERSION=${VERSION:-1.3.21}
+VERSION=${VERSION:-1.3.25}
 BUILD=${BUILD:-1}
 TAG=${TAG:-}
 
-SRCURL="http://downloads.sourceforge.net/graphicsmagick/${PRGNAM}-${VERSION}.tar.bz2"
+SRCURL="https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/${VERSION}/GraphicsMagick-${VERSION}.tar.xz"
+ARCHIVE_TYPE="tar.xz"
 source ../../get-source.sh
 getsource_fn
 

--- a/Misc/libpng/libpng.SlackBuild
+++ b/Misc/libpng/libpng.SlackBuild
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Copyright 2015-2017  tde-slackbuilds project on GitHub
+# All rights reserved.
+#
+#   Permission to use, copy, modify, and distribute this software for
+#   any purpose with or without fee is hereby granted, provided that
+#   the above copyright notice and this permission notice appear in all
+#   copies.
+#
+#   THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+#   WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+#   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#   IN NO EVENT SHALL THE AUTHORS AND COPYRIGHT HOLDERS AND THEIR
+#   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+#   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+#   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+#   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+#   SUCH DAMAGE.
+
+PRGNAM=libpng
+VERSION=${VERSION:-1.4.20}
+BUILD=${BUILD:-1}
+TAG=${TAG:-}
+
+SRCURL="https://downloads.sourceforge.net/project/libpng/libpng14/$VERSION/libpng-$VERSION.tar.xz"
+ARCHIVE_TYPE="tar.xz"
+
+source ../../get-source.sh
+getsource_fn
+
+untar_fn
+
+listdocs_fn
+
+chown_fn
+
+cd_builddir_fn
+
+CFLAGS="$SLKCFLAGS" \
+../configure \
+  --prefix=/usr \
+  --sysconfdir=/etc \
+  --libdir=/usr/lib${LIBDIRSUFFIX} \
+  --includedir=/usr/include \
+  --mandir=/usr/man \
+  --disable-static
+
+make_fn
+
+installdocs_fn
+
+mangzip_fn
+
+strip_fn
+
+mkdir_install_fn
+
+echo "
+# HOW TO EDIT THIS FILE:
+# The 'handy ruler' below makes it easier to edit a package description.  Line
+# up the first '|' above the ':' following the base package name, and the '|'
+# on the right side marks the last column you can put a character in.  You must
+# make exactly 11 lines for the formatting to be correct.  It's also
+# customary to leave one space after the ':'.
+
+$PRGNAM|-----handy-ruler------------------------------------------------------|
+$PRGNAM: $PRGNAM (Portable Network Graphics library)
+$PRGNAM:
+$PRGNAM: PNG (Portable Network Graphics) is an extensible file format for the
+$PRGNAM: lossless, portable, well-compressed storage of raster images.  PNG
+$PRGNAM: provides a patent-free replacement for GIF and can also replace many
+$PRGNAM: common uses of TIFF.  Indexed-color, grayscale, and truecolor images
+$PRGNAM: are supported, plus an optional alpha channel.  Sample depths range
+$PRGNAM: from 1 to 16 bits.
+$PRGNAM:
+$PRGNAM:
+$PRGNAM:
+" > $PKG/install/slack-desc
+
+makepkg_fn

--- a/get-source.sh
+++ b/get-source.sh
@@ -235,3 +235,16 @@ cat $PKG/install/slack-desc | grep "^${PRGNAM}" | grep -v handy > $OUTPUT/${PRGN
 umask ${_UMASK_}
 }
 
+libpng16_fn ()
+{
+(cd /usr/bin
+ln -sf libpng16-config libpng-config )
+(cd /usr/include
+ln -sf libpng16/pngconf.h pngconf.h
+ln -sf libpng16/png.h png.h )
+(cd /usr/lib64/pkgconfig
+ln -sf libpng16.pc libpng.pc )
+(cd /usr/lib64
+ln -sf libpng16.so libpng.so
+ln -sf libpng16.la libpng.la )
+}


### PR DESCRIPTION
Options to build with libpng-1.4, GraphicsMagick, and change app name from chalk to krita.

Modified BUILD-TDE.sh to include new dialog screen to select above options for chalk if koffice build is chosen - libpng-1.4 is only intended for building chalk/krita and will only be built if selected in this screen.

Updated GraphicsMagick.SB to build with latest version 1.3.25

Changed libpng-1.4 download URL - the ftp download was too slow and caused the build to fail.